### PR TITLE
Add TypeScript to the list of dependencies

### DIFF
--- a/collect-stats.ts
+++ b/collect-stats.ts
@@ -58,6 +58,7 @@ const PACKAGES = [
   "react",
   "@emotion/react",
   "tailwindcss",
+  "typescript",
 ];
 
 async function fetchWithRetry(url: string, retries = 3): Promise<Response> {


### PR DESCRIPTION
Why: https://mui.com/material-ui/getting-started/supported-platforms/#typescript.