### PR TITLE
Add @base-ui/react to dependencies

### DIFF
--- a/collect-stats.ts
+++ b/collect-stats.ts
@@ -55,7 +55,8 @@ const PACKAGES = [
   "@mui/x-license",
   "@mui/x-internals",
   "@mui/x-telemetry",
-
+  
+  "@base-ui-components/react",
   "@base-ui/react",
 
   "react",

--- a/collect-stats.ts
+++ b/collect-stats.ts
@@ -55,7 +55,6 @@ const PACKAGES = [
   "@mui/x-license",
   "@mui/x-internals",
   "@mui/x-telemetry",
-  
   "@base-ui-components/react",
   "@base-ui/react",
 

--- a/collect-stats.ts
+++ b/collect-stats.ts
@@ -55,6 +55,7 @@ const PACKAGES = [
   "@mui/x-license",
   "@mui/x-internals",
   "@mui/x-telemetry",
+
   "@base-ui-components/react",
   "@base-ui/react",
 

--- a/collect-stats.ts
+++ b/collect-stats.ts
@@ -57,6 +57,7 @@ const PACKAGES = [
   "@mui/x-telemetry",
 
   "@base-ui-components/react",
+  "@base-ui/react",
 
   "react",
   "@emotion/react",

--- a/collect-stats.ts
+++ b/collect-stats.ts
@@ -56,7 +56,6 @@ const PACKAGES = [
   "@mui/x-internals",
   "@mui/x-telemetry",
 
-  "@base-ui-components/react",
   "@base-ui/react",
 
   "react",


### PR DESCRIPTION
We don't plan breaking changes any time soon, but I'm curious to see how fast people move between minors.

(Context: I was looking for reminiscences of @base-ui-components/react in our codebase, e.g. opened https://github.com/mui/mui-public/issues/993 for https://github.com/mui/base-ui/issues/488). 